### PR TITLE
Add "quiet" option like tail

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ctail /var/log/messages /var/log/syslog
 ctail /var/log/messages --date
 ```
 
-![Example](https://space.mdoetsch.de/index.php/apps/files_sharing/ajax/publicpreview.php?x=1307&y=790&a=true&file=ctail.png&t=JXjauX3O4qls9kQ&scalingup=0)
+![Example](https://mdoetsch.de/wp-content/uploads/2015/05/ctail.png)
 
 
 Options

--- a/ctail.js
+++ b/ctail.js
@@ -21,6 +21,11 @@ var opts = nomnom
         flag: true,
         help: 'Print debugging info'
     })
+    .option('quiet', {
+        abbr: 'q',
+        flag: true,
+        help: 'Never output headers giving file names'
+    })
     .option('style', {
         list: ['rainbow', 'zebra', 'america', 'random', 'trap'],
         help: 'Color style'

--- a/lib/ctail.js
+++ b/lib/ctail.js
@@ -39,7 +39,7 @@ CTail.prototype.tail = function() {
             var tail = new Tail(file);
 
             tail.on("line", function (data) {
-                if (lastFile != file) {
+                if (lastFile != file && !self.options.quiet) {
                     console.log('==> ' + color(file) + ' <==');
                     lastFile = file;
                 }


### PR DESCRIPTION
```
  -q, --quiet, --silent    never output headers giving file names
```
